### PR TITLE
feat(flake.nix): added nix flake to build easy

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1736798957,
+        "narHash": "sha256-qwpCtZhSsSNQtK4xYGzMiyEDhkNzOCz/Vfu4oL2ETsQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9abb87b552b7f55ac8916b6fc9e5cb486656a2f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "A flake for building and developing the ghost C CLI tool";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+    in {
+      packages = {
+        ghost = pkgs.stdenv.mkDerivation {
+          pname = "ghost";
+          version = "0.0.1";
+
+          src = ./.;
+
+          buildInputs = [pkgs.clang pkgs.libbsd];
+
+          buildPhase = ''
+            mkdir -p $out/bin
+            ${pkgs.clang}/bin/clang -std=c99 -O3 -march=native -flto -ffast-math \
+              -D_DEFAULT_SOURCE -D_BSD_SOURCE -D_POSIX_C_SOURCE=200809L \
+              src/ghost.c src/frames.c -o $out/bin/ghost
+          '';
+
+          installPhase = "true";
+
+          meta = with pkgs.lib; {
+            description = "A C CLI tool for terminal animations";
+            license = licenses.mit;
+            maintainers = ["theMackabu" "linuxmobile"];
+            platforms = platforms.linux;
+          };
+        };
+        default = self.packages.${system}.ghost;
+      };
+
+      devShell = pkgs.mkShell {
+        buildInputs = [pkgs.clang pkgs.cmake pkgs.libbsd pkgs.maid];
+      };
+    });
+}


### PR DESCRIPTION
Since you don't have a readme put together, I didn't want to add the instructions, but in short, it can be done:

### Using Flakes

1. **Clone the repository:**

   ```sh
   git clone https://github.com/yourusername/ghost.git
   cd ghost
   ```

2. **Build the `ghost` package using Flakes:**

   ```sh
   nix build .#ghost
   ```

   This will build the `ghost` package and place the result in the `./result` directory.

3. **Run the `ghost` binary:**

   ```sh
   ./result/bin/ghost
   ```

### Using Nix Configuration

To include the `ghost` package in your NixOS configuration, you can add it to your `configuration.nix` file.

1. **Add the Flake input to your `configuration.nix`:**

   ```nix
   {
     inputs = {
       nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
       flake-utils.url = "github:numtide/flake-utils";
       ghost.url = "path:./path/to/your/ghost/repo";
     };

     outputs = { self, nixpkgs, flake-utils, ghost }: {
       nixosConfigurations = {
         hostname = nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
           modules = [
             ./hardware-configuration.nix
             {
               imports = [ ghost.nixosModules.default ];

               environment.systemPackages = with pkgs; [
                 ghost.packages.x86_64-linux.ghost
               ];
             }
           ];
         };
       };
     };
   }
   ```

2. **Rebuild your NixOS system:**

   ```sh
   sudo nixos-rebuild switch --flake .#hostname
   ```

### Using Nix Profile with GitHub

1. **Install the `ghost` package into your profile directly from GitHub:**

   ```sh
   nix profile install github:linuxmobile/ghost#ghost
   ```

2. **Run the `ghost` binary:**

   ```sh
   ghost
   ```

